### PR TITLE
Limit observation_period_end_date to current date

### DIFF
--- a/feasibility/sql/stratified_person.R
+++ b/feasibility/sql/stratified_person.R
@@ -2,7 +2,8 @@ db_year_range_sql <- render(
         'SELECT
   MIN("observation_period_1"."observation_period_end_date") AS "first_year",
   MAX("observation_period_1"."observation_period_end_date") AS "last_year"
-FROM @schema."observation_period" AS "observation_period_1";',
+FROM @schema."observation_period" AS "observation_period_1"
+WHERE "observation_period_1"."observation_period_end_date" <= GETDATE();',
         schema = schema
 )
 db_year_range_sql <- translate(sql = db_year_range_sql, targetDialect = dbms)


### PR DESCRIPTION
Fixes #39 
By limiting the end_date to current date, age groups are created without NAs

## PR Checklist

If you are contributing to `MentalHealthEquity`, please make sure you are able to check off each item on this list:

- [x] Did I make sure to only change the part of the file where I introduced a new change/feature?
- [x] Did I cover all corner cases to be close to 100% test coverage (if applicable)?
- [x] Did I properly add dependencies to the and set an upper bound of the dependency (if applicable)?
- [x] Did I clearly articulate why this PR was made the way it was and how it was made?

**Link to relevant issue(s)**
Closes #39 


**How did you address these issues with this PR? What methods did you use?**



